### PR TITLE
Various minor fixes

### DIFF
--- a/classes/AbstractSandboxTask.php
+++ b/classes/AbstractSandboxTask.php
@@ -79,7 +79,7 @@ abstract class WSAL_AbstractSandboxTask {
 	/**
 	 * Method: Show progress.
 	 *
-	 * @param mix $percent - Progress percentage.
+	 * @param mixed $percent - Progress percentage.
 	 */
 	protected function Progress( $percent ) {
 		echo '<script>bar.style.width=prg.innerHTML="' . number_format( $percent, 2 ) . '%";</script>';

--- a/classes/AbstractSensor.php
+++ b/classes/AbstractSensor.php
@@ -56,7 +56,7 @@ abstract class WSAL_AbstractSensor {
 	 *
 	 * @param int    $type    - Type of alert.
 	 * @param string $message - Alert message.
-	 * @param mix    $args    - Message arguments.
+	 * @param mixed  $args    - Message arguments.
 	 */
 	protected function Log( $type, $message, $args ) {
 		$this->plugin->alerts->Trigger(
@@ -72,7 +72,7 @@ abstract class WSAL_AbstractSensor {
 	 * Method: Log error message for sensor.
 	 *
 	 * @param string $message - Alert message.
-	 * @param mix    $args    - Message arguments.
+	 * @param mixed  $args    - Message arguments.
 	 */
 	protected function LogError( $message, $args ) {
 		$this->Log( 0001, $message, $args );
@@ -82,7 +82,7 @@ abstract class WSAL_AbstractSensor {
 	 * Method: Log warning message for sensor.
 	 *
 	 * @param string $message - Alert message.
-	 * @param mix    $args    - Message arguments.
+	 * @param mixed  $args    - Message arguments.
 	 */
 	protected function LogWarn( $message, $args ) {
 		$this->Log( 0002, $message, $args );
@@ -92,7 +92,7 @@ abstract class WSAL_AbstractSensor {
 	 * Method: Log info message for sensor.
 	 *
 	 * @param string $message - Alert message.
-	 * @param mix    $args    - Message arguments.
+	 * @param mixed  $args    - Message arguments.
 	 */
 	protected function LogInfo( $message, $args ) {
 		$this->Log( 0003, $message, $args );

--- a/classes/Adapters/MySQL/ActiveRecordAdapter.php
+++ b/classes/Adapters/MySQL/ActiveRecordAdapter.php
@@ -68,7 +68,7 @@ class WSAL_Adapters_MySQL_ActiveRecord implements WSAL_Adapters_ActiveRecordInte
 	 * @return WSAL_Models_ActiveRecord
 	 */
 	public function GetModel() {
-		return new WSAL_Models_ActiveRecord();
+		throw new RuntimeException('GetModel() should have been overridden in ' . get_class($this));
 	}
 
 	/**
@@ -357,7 +357,7 @@ class WSAL_Adapters_MySQL_ActiveRecord implements WSAL_Adapters_ActiveRecordInte
 	 *
 	 * @param string $query Full SQL query.
 	 * @param array  $args (Optional) Query arguments.
-	 * @return self[] List of loaded records.
+	 * @return array List of loaded records.
 	 */
 	public function LoadMultiQuery( $query, $args = array() ) {
 		$_wpdb = $this->connection;
@@ -373,7 +373,7 @@ class WSAL_Adapters_MySQL_ActiveRecord implements WSAL_Adapters_ActiveRecordInte
 	/**
 	 * Table install query.
 	 *
-	 * @param string $prefix - (Optional) Table prefix.
+	 * @param string|false $prefix - (Optional) Table prefix.
 	 * @return string - Must return SQL for creating table.
 	 */
 	protected function _GetInstallQuery( $prefix = false ) {

--- a/classes/Adapters/MySQL/MetaAdapter.php
+++ b/classes/Adapters/MySQL/MetaAdapter.php
@@ -67,7 +67,7 @@ class WSAL_Adapters_MySQL_Meta extends WSAL_Adapters_MySQL_ActiveRecord implemen
 	/**
 	 * Meta value.
 	 *
-	 * @var mix
+	 * @var mixed
 	 */
 	public $value = array(); // Force mixed type.
 
@@ -117,7 +117,7 @@ class WSAL_Adapters_MySQL_Meta extends WSAL_Adapters_MySQL_ActiveRecord implemen
 	 *
 	 * @param string $meta_name - Metadata name.
 	 * @param string $occurence_id - Metadata occurrence_id.
-	 * @return WSAL_Meta[]
+	 * @return WSAL_Models_Meta[]
 	 */
 	public function LoadByNameAndOccurenceId( $meta_name, $occurence_id ) {
 		return $this->Load( 'occurrence_id = %d AND name = %s', array( $occurence_id, $meta_name ) );

--- a/classes/Adapters/MySQL/OccurrenceAdapter.php
+++ b/classes/Adapters/MySQL/OccurrenceAdapter.php
@@ -219,13 +219,13 @@ class WSAL_Adapters_MySQL_Occurrence extends WSAL_Adapters_MySQL_ActiveRecord im
 	}
 
 	/**
-	 * Gets occurences of the alert 1003.
+	 * Gets occurrences of the alert 1003.
 	 *
 	 * @param array $args - User arguments.
-	 * @return WSAL_Occurrence[]
+	 * @return WSAL_Models_Occurrence[]
 	 */
 	public function check_alert_1003( $args = array() ) {
-		return self::LoadMultiQuery(
+		return $this->LoadMultiQuery(
 			'SELECT occurrence.* FROM `' . $this->GetTable() . '` occurrence
 			WHERE (occurrence.alert_id = %d)
 			AND (occurrence.site_id = %d)
@@ -291,7 +291,7 @@ class WSAL_Adapters_MySQL_Occurrence extends WSAL_Adapters_MySQL_ActiveRecord im
 	}
 
 	/**
-	 * Gets occurences of the same type by IP within specified time frame.
+	 * Gets occurrences of the same type by IP within specified time frame.
 	 *
 	 * @param array $args - Query Arguments.
 	 * @return WSAL_Models_Occurrence[]

--- a/classes/Adapters/MySQL/OccurrenceAdapter.php
+++ b/classes/Adapters/MySQL/OccurrenceAdapter.php
@@ -38,7 +38,7 @@ class WSAL_Adapters_MySQL_Occurrence extends WSAL_Adapters_MySQL_ActiveRecord im
 	/**
 	 * Meta data.
 	 *
-	 * @var WSAL_Meta
+	 * @var WSAL_Models_Meta
 	 */
 	protected $_meta;
 
@@ -117,7 +117,7 @@ class WSAL_Adapters_MySQL_Occurrence extends WSAL_Adapters_MySQL_ActiveRecord im
 	 *
 	 * @param object $occurence - Occurrence model instance.
 	 * @see WSAL_Adapters_MySQL_ActiveRecord::Load()
-	 * @return WSAL_Meta
+	 * @return WSAL_Models_Meta
 	 */
 	public function GetMeta( $occurence ) {
 		if ( ! isset( $this->_meta ) ) {
@@ -132,7 +132,7 @@ class WSAL_Adapters_MySQL_Occurrence extends WSAL_Adapters_MySQL_ActiveRecord im
 	 *
 	 * @param object $occurence - Occurrence model instance.
 	 * @see WSAL_Adapters_MySQL_ActiveRecord::LoadArray()
-	 * @return WSAL_Meta[]
+	 * @return WSAL_Models_Meta[]
 	 */
 	public function GetMultiMeta( $occurence ) {
 		if ( ! isset( $this->_meta ) ) {
@@ -148,7 +148,7 @@ class WSAL_Adapters_MySQL_Occurrence extends WSAL_Adapters_MySQL_ActiveRecord im
 	 * @param object $occurence - Occurrence model instance.
 	 * @param string $name - Meta name.
 	 * @see WSAL_Adapters_MySQL_ActiveRecord::Load()
-	 * @return WSAL_Meta The meta item, be sure to checked if it was loaded successfully.
+	 * @return WSAL_Models_Meta The meta item, be sure to checked if it was loaded successfully.
 	 */
 	public function GetNamedMeta( $occurence, $name ) {
 		$meta = new WSAL_Adapters_MySQL_Meta( $this->connection );
@@ -159,53 +159,32 @@ class WSAL_Adapters_MySQL_Occurrence extends WSAL_Adapters_MySQL_ActiveRecord im
 	/**
 	 * Returns the first meta value from a given set of names. Useful when you have a mix of items that could provide a particular detail.
 	 *
-	 * @param object $occurence - Occurrence model instance.
+	 * @param object $occurrence - Occurrence model instance.
 	 * @param array  $names - List of meta names.
-	 * @return WSAL_Meta The first meta item that exists.
+	 * @return WSAL_Models_Meta The first meta item that exists.
 	 */
-	public function GetFirstNamedMeta( $occurence, $names ) {
+	public function GetFirstNamedMeta( $occurrence, $names ) {
 		$meta = new WSAL_Adapters_MySQL_Meta( $this->connection );
 		$query = '(' . str_repeat( 'name = %s OR ', count( $names ) ) . '0)';
 		$query = 'occurrence_id = %d AND ' . $query . ' ORDER BY name DESC LIMIT 1';
-		array_unshift( $names, $occurence->id ); // Prepend args with occurrence id.
+		array_unshift( $names, $occurrence->id ); // Prepend args with occurrence id.
 
 				$this->_meta = $meta->Load( $query, $names );
 		return $meta->getModel()->LoadData( $this->_meta );
 
-		// TO DO: Do we want to reintroduce is loaded check/logic?
+		// TODO: Do we want to reintroduce is loaded check/logic?
 		// return $meta->IsLoaded() ? $meta : null;
 	}
 
 	/**
-	 * Returns newest unique occurrences.
-	 *
-	 * @param integer $limit Maximum limit.
-	 * @return WSAL_Occurrence[]
-	 */
-	public static function GetNewestUnique( $limit = PHP_INT_MAX ) {
-		$temp = new self();
-		return self::LoadMultiQuery('
-			SELECT *, COUNT(alert_id) as count
-			FROM (
-				SELECT *
-				FROM ' . $temp->GetTable() . '
-				ORDER BY created_on DESC
-			) AS temp_table
-			GROUP BY alert_id
-			LIMIT %d
-			', array( $limit )
-		);
-	}
-
-	/**
-	 * Gets occurences of the same type by IP and Username within specified time frame.
+	 * Gets occurrences of the same type by IP and Username within specified time frame.
 	 *
 	 * @param array $args - User arguments.
-	 * @return WSAL_Occurrence[]
+	 * @return WSAL_Models_Occurrence[]
 	 */
 	public function CheckKnownUsers( $args = array() ) {
 		$tt2 = new WSAL_Adapters_MySQL_Meta( $this->connection );
-		return self::LoadMultiQuery(
+		return $this->LoadMultiQuery(
 			'SELECT occurrence.* FROM `' . $this->GetTable() . '` occurrence
 			INNER JOIN `' . $tt2->GetTable() . '` ipMeta on ipMeta.occurrence_id = occurrence.id
 			and ipMeta.name = "ClientIP"
@@ -221,14 +200,14 @@ class WSAL_Adapters_MySQL_Occurrence extends WSAL_Adapters_MySQL_ActiveRecord im
 	}
 
 	/**
-	 * Gets occurences of the same type by IP within specified time frame.
+	 * Gets occurrences of the same type by IP within specified time frame.
 	 *
 	 * @param array $args - User arguments.
-	 * @return WSAL_Occurrence[]
+	 * @return WSAL_Models_Occurrence[]
 	 */
 	public function CheckUnKnownUsers( $args = array() ) {
 		$tt2 = new WSAL_Adapters_MySQL_Meta( $this->connection );
-		return self::LoadMultiQuery(
+		return $this->LoadMultiQuery(
 			'SELECT occurrence.* FROM `' . $this->GetTable() . '` occurrence
 			INNER JOIN `' . $tt2->GetTable() . '` ipMeta on ipMeta.occurrence_id = occurrence.id
 			and ipMeta.name = "ClientIP" and ipMeta.value = %s
@@ -260,6 +239,8 @@ class WSAL_Adapters_MySQL_Occurrence extends WSAL_Adapters_MySQL_ActiveRecord im
 	 * Add conditions to the Query
 	 *
 	 * @param string $query - Query.
+	 *
+	 * @return string[]
 	 */
 	protected function prepareOccurrenceQuery( $query ) {
 		$search_query_parameters = array();
@@ -294,11 +275,11 @@ class WSAL_Adapters_MySQL_Occurrence extends WSAL_Adapters_MySQL_ActiveRecord im
 	 * Gets occurrence by Post_id.
 	 *
 	 * @param int $post_id - Post ID.
-	 * @return WSAL_Occurrence[]
+	 * @return WSAL_Models_Occurrence[]
 	 */
 	public function GetByPostID( $post_id ) {
 		$tt2 = new WSAL_Adapters_MySQL_Meta( $this->connection );
-		return self::LoadMultiQuery(
+		return $this->LoadMultiQuery(
 			'SELECT occurrence.* FROM `' . $this->GetTable() . '`AS occurrence
 			INNER JOIN `' . $tt2->GetTable() . '`AS postMeta ON postMeta.occurrence_id = occurrence.id
 			and postMeta.name = "PostID"
@@ -313,11 +294,11 @@ class WSAL_Adapters_MySQL_Occurrence extends WSAL_Adapters_MySQL_ActiveRecord im
 	 * Gets occurences of the same type by IP within specified time frame.
 	 *
 	 * @param array $args - Query Arguments.
-	 * @return WSAL_Occurrence[]
+	 * @return WSAL_Models_Occurrence[]
 	 */
 	public function CheckAlert404( $args = array() ) {
 		$tt2 = new WSAL_Adapters_MySQL_Meta( $this->connection );
-		return self::LoadMultiQuery(
+		return $this->LoadMultiQuery(
 			'SELECT occurrence.* FROM `' . $this->GetTable() . '` occurrence
 			INNER JOIN `' . $tt2->GetTable() . '` ipMeta on ipMeta.occurrence_id = occurrence.id
 			and ipMeta.name = "ClientIP" and ipMeta.value = %s

--- a/classes/Adapters/MySQL/OptionAdapter.php
+++ b/classes/Adapters/MySQL/OptionAdapter.php
@@ -59,7 +59,7 @@ class WSAL_Adapters_MySQL_Option extends WSAL_Adapters_MySQL_ActiveRecord {
 	/**
 	 * Option value.
 	 *
-	 * @var mix
+	 * @var mixed
 	 */
 	public $option_value = '';
 

--- a/classes/Adapters/MySQL/TmpUserAdapter.php
+++ b/classes/Adapters/MySQL/TmpUserAdapter.php
@@ -52,7 +52,7 @@ class WSAL_Adapters_MySQL_TmpUser extends WSAL_Adapters_MySQL_ActiveRecord {
 	/**
 	 * Must return SQL for creating table.
 	 *
-	 * @param mix $prefix - Prefix.
+	 * @param mixed $prefix - Prefix.
 	 * @return string
 	 */
 	protected function _GetInstallQuery( $prefix = false ) {

--- a/classes/Adapters/OccurrenceInterface.php
+++ b/classes/Adapters/OccurrenceInterface.php
@@ -39,17 +39,10 @@ interface WSAL_Adapters_OccurrenceInterface {
 	 * Useful when you have a mix of items that could provide
 	 * a particular detail.
 	 *
-	 * @param object $occurence - Instance of occurence object.
+	 * @param object $occurrence - Instance of occurrence object.
 	 * @param array  $names - List of Meta names.
 	 */
-	public function GetFirstNamedMeta( $occurence, $names );
-
-	/**
-	 * Returns newest unique occurrences.
-	 *
-	 * @param integer $limit - Maximum limit.
-	 */
-	public static function GetNewestUnique( $limit = PHP_INT_MAX );
+	public function GetFirstNamedMeta( $occurrence, $names );
 
 	/**
 	 * Gets occurences of the same type by IP and Username within specified time frame.

--- a/classes/Adapters/OccurrenceInterface.php
+++ b/classes/Adapters/OccurrenceInterface.php
@@ -45,14 +45,14 @@ interface WSAL_Adapters_OccurrenceInterface {
 	public function GetFirstNamedMeta( $occurrence, $names );
 
 	/**
-	 * Gets occurences of the same type by IP and Username within specified time frame.
+	 * Gets occurrences of the same type by IP and Username within specified time frame.
 	 *
 	 * @param array $args - Arguments.
 	 */
 	public function CheckKnownUsers( $args = array() );
 
 	/**
-	 * Gets occurences of the same type by IP within specified time frame.
+	 * Gets occurrences of the same type by IP within specified time frame.
 	 *
 	 * @param array $args - Arguments.
 	 */

--- a/classes/AlertManager.php
+++ b/classes/AlertManager.php
@@ -165,7 +165,7 @@ final class WSAL_AlertManager {
 	 *
 	 * @param integer $type - Alert type.
 	 * @param array   $data - Alert data.
-	 * @param mix     $delayed - False if delayed, function if not.
+	 * @param mixed   $delayed - False if delayed, function if not.
 	 */
 	public function Trigger( $type, $data = array(), $delayed = false ) {
 		// Get buffer use option.

--- a/classes/AuditLogListView.php
+++ b/classes/AuditLogListView.php
@@ -547,7 +547,7 @@ class WSAL_AuditLogListView extends WP_List_Table {
 	 * Method: Meta data formater.
 	 *
 	 * @param string $name - Name of the data.
-	 * @param mix    $value - Value of the data.
+	 * @param mixed  $value - Value of the data.
 	 * @return string
 	 */
 	public function meta_formatter( $name, $value ) {
@@ -634,7 +634,7 @@ class WSAL_AuditLogListView extends WP_List_Table {
 				return '<a href="javascript:;" onclick="download_failed_login_log( this )" data-download-nonce="' . esc_attr( wp_create_nonce( 'wsal-download-failed-logins' ) ) . '" title="' . esc_html__( 'Download the log file.', 'wp-security-audit-log' ) . '">' . esc_html__( 'Download the log file.', 'wp-security-audit-log' ) . '</a>';
 
 			case strncmp( $value, 'http://', 7 ) === 0:
-			case strncmp( $value, 'https://', 7 ) === 0:
+			case strncmp( $value, 'https://', 8 ) === 0:
 				return '<a href="' . esc_html( $value ) . '" title="' . esc_html( $value ) . '" target="_blank">' . esc_html( $value ) . '</a>';
 
 			case '%PostStatus%' === $name:

--- a/classes/Connector/ConnectorInterface.php
+++ b/classes/Connector/ConnectorInterface.php
@@ -23,6 +23,8 @@ interface WSAL_Connector_ConnectorInterface {
 	 * Gets the adapter.
 	 *
 	 * @param string $class_name - Class name.
+	 *
+	 * @return WSAL_Adapters_ActiveRecordInterface
 	 */
 	public function getAdapter( $class_name );
 

--- a/classes/Connector/MySQLDB.php
+++ b/classes/Connector/MySQLDB.php
@@ -62,7 +62,7 @@ class WSAL_Connector_MySQLDB extends WSAL_Connector_AbstractConnector implements
 	/**
 	 * Creates a connection and returns it
 	 *
-	 * @return Instance of WPDB
+	 * @return wpdb Instance of WPDB
 	 */
 	private function createConnection() {
 		if ( ! empty( $this->connectionConfig ) ) {
@@ -105,7 +105,7 @@ class WSAL_Connector_MySQLDB extends WSAL_Connector_AbstractConnector implements
 	 * Gets an adapter for the specified model.
 	 *
 	 * @param string $class_name - Class name.
-	 * @return WSAL_Adapters_MySQL_{class_name}
+	 * @return WSAL_Adapters_ActiveRecordInterface
 	 */
 	public function getAdapter( $class_name ) {
 		$obj_name = $this->getAdapterClassName( $class_name );
@@ -116,7 +116,7 @@ class WSAL_Connector_MySQLDB extends WSAL_Connector_AbstractConnector implements
 	 * Gets an adapter class name for the specified model.
 	 *
 	 * @param string $class_name - Class name.
-	 * @return WSAL_Adapters_MySQL_{class_name}
+	 * @return string
 	 */
 	protected function getAdapterClassName( $class_name ) {
 		return 'WSAL_Adapters_MySQL_' . $class_name;

--- a/classes/ConstantManager.php
+++ b/classes/ConstantManager.php
@@ -81,7 +81,7 @@ class WSAL_ConstantManager {
 	 *
 	 * @param string $what - The type of detail: 'name', 'value'.
 	 * @param mixed  $value - The detail expected value.
-	 * @param mix    $default - Default value of constant.
+	 * @param mixed  $default - Default value of constant.
 	 * @throws string - Error if detail type is unexpected.
 	 * @return mixed Either constant details (props: name, value, description) or $default if not found.
 	 */

--- a/classes/Models/ActiveRecord.php
+++ b/classes/Models/ActiveRecord.php
@@ -142,6 +142,8 @@ abstract class WSAL_Models_ActiveRecord {
 	 * based on the adapter name.
 	 *
 	 * @see WSAL_Connector_ConnectorInterface::getAdapter()
+	 *
+	 * @return WSAL_Adapters_ActiveRecordInterface
 	 */
 	public function getAdapter() {
 		return $this->getConnector()->getAdapter( $this->adapterName );

--- a/classes/Models/Occurrence.php
+++ b/classes/Models/Occurrence.php
@@ -253,20 +253,20 @@ class WSAL_Models_Occurrence extends WSAL_Models_ActiveRecord {
 	}
 
 	/**
-	 * Finds occurences of the same type by IP and Username within specified time frame.
+	 * Finds occurrences of the same type by IP and Username within specified time frame.
 	 *
 	 * @param array $args - Query args.
-	 * @return WSAL_Occurrence[]
+	 * @return WSAL_Models_Occurrence[]
 	 */
 	public function CheckKnownUsers( $args = array() ) {
 		return $this->getAdapter()->CheckKnownUsers( $args );
 	}
 
 	/**
-	 * Finds occurences of the same type by IP within specified time frame.
+	 * Finds occurrences of the same type by IP within specified time frame.
 	 *
 	 * @param array $args - Query args.
-	 * @return WSAL_Occurrence[]
+	 * @return WSAL_Models_Occurrence[]
 	 */
 	public function CheckUnKnownUsers( $args = array() ) {
 		return $this->getAdapter()->CheckUnKnownUsers( $args );
@@ -287,18 +287,18 @@ class WSAL_Models_Occurrence extends WSAL_Models_ActiveRecord {
 	 *
 	 * @see WSAL_Adapters_MySQL_Occurrence::GetByPostID()
 	 * @param integer $post_id - Post ID.
-	 * @return WSAL_Occurrence[]
+	 * @return WSAL_Models_Occurrence[]
 	 */
 	public function GetByPostID( $post_id ) {
 		return $this->getAdapter()->GetByPostID( $post_id );
 	}
 
 	/**
-	 * Gets occurences of the same type by IP within specified time frame.
+	 * Gets occurrences of the same type by IP within specified time frame.
 	 *
 	 * @see WSAL_Adapters_MySQL_Occurrence::CheckAlert404()
 	 * @param array $args - Query args.
-	 * @return WSAL_Occurrence[]
+	 * @return WSAL_Models_Occurrence[]
 	 */
 	public function CheckAlert404( $args = array() ) {
 		return $this->getAdapter()->CheckAlert404( $args );

--- a/classes/Models/Occurrence.php
+++ b/classes/Models/Occurrence.php
@@ -273,10 +273,10 @@ class WSAL_Models_Occurrence extends WSAL_Models_ActiveRecord {
 	}
 
 	/**
-	 * Finds occurences of the alert 1003.
+	 * Finds occurrences of the alert 1003.
 	 *
 	 * @param array $args - Query args.
-	 * @return WSAL_Occurrence[]
+	 * @return WSAL_Models_Occurrence[]
 	 */
 	public function check_alert_1003( $args = array() ) {
 		return $this->getAdapter()->check_alert_1003( $args );

--- a/classes/Nicer.php
+++ b/classes/Nicer.php
@@ -15,7 +15,7 @@ class WSAL_Nicer {
 	/**
 	 * Input string.
 	 *
-	 * @var mix
+	 * @var mixed
 	 */
 	protected $value;
 

--- a/classes/Sensors/BBPress.php
+++ b/classes/Sensors/BBPress.php
@@ -83,7 +83,7 @@ class WSAL_Sensors_BBPress extends WSAL_AbstractSensor {
 		if ( isset( $post_array['post_ID'] )
 			&& isset( $post_array['_wpnonce'] )
 			&& ! wp_verify_nonce( $post_array['_wpnonce'], 'update-post_' . $post_array['post_ID'] ) ) {
-			return false;
+			return;
 		}
 
 		if ( isset( $post_array ) && isset( $post_array['post_ID'] )

--- a/classes/Sensors/Content.php
+++ b/classes/Sensors/Content.php
@@ -396,6 +396,10 @@ class WSAL_Sensors_Content extends WSAL_AbstractSensor {
 	 * @return string - Full path to file.
 	 */
 	protected function GetPostTemplate( $post ) {
+		if ( ! isset( $post->ID ) ) {
+			return '';
+		}
+
 		$id       = $post->ID;
 		$template = get_page_template_slug( $id );
 		$pagename = $post->post_name;
@@ -422,6 +426,10 @@ class WSAL_Sensors_Content extends WSAL_AbstractSensor {
 	 * @return array - List of categories.
 	 */
 	protected function GetPostCategories( $post ) {
+		if ( ! isset( $post->ID ) ) {
+			return array();
+		}
+
 		return wp_get_post_categories(
 			$post->ID, array(
 				'fields' => 'names',
@@ -436,6 +444,10 @@ class WSAL_Sensors_Content extends WSAL_AbstractSensor {
 	 * @return array - List of tags.
 	 */
 	protected function get_post_tags( $post ) {
+		if ( ! isset( $post->ID ) ) {
+			return array();
+		}
+
 		return wp_get_post_tags(
 			$post->ID, array(
 				'fields' => 'names',
@@ -1102,16 +1114,16 @@ class WSAL_Sensors_Content extends WSAL_AbstractSensor {
 	 */
 	protected function check_tags_change( $old_tags, $new_tags, $post ) {
 		// Check for added tags.
-		$added_tags = array_diff( $new_tags, $old_tags );
+		$added_tags = array_diff( (array) $new_tags, (array) $old_tags );
 
 		// Check for removed tags.
-		$removed_tags = array_diff( $old_tags, $new_tags );
+		$removed_tags = array_diff( (array) $old_tags, (array) $new_tags );
 
 		// Convert tags arrays to string.
 		$old_tags     = implode( ', ', (array) $old_tags );
 		$new_tags     = implode( ', ', (array) $new_tags );
-		$added_tags   = implode( ', ', (array) $added_tags );
-		$removed_tags = implode( ', ', (array) $removed_tags );
+		$added_tags   = implode( ', ', $added_tags );
+		$removed_tags = implode( ', ', $removed_tags );
 
 		// Declare event variables.
 		$add_event    = '';

--- a/classes/Sensors/MetaData.php
+++ b/classes/Sensors/MetaData.php
@@ -129,7 +129,7 @@ class WSAL_Sensors_MetaData extends WSAL_AbstractSensor {
 	 *
 	 * @param int    $object_id - Object ID.
 	 * @param string $meta_key - Meta key.
-	 * @param mix    $meta_value - Meta value.
+	 * @param mixed  $meta_value - Meta value.
 	 */
 	public function EventPostMetaCreated( $object_id, $meta_key, $meta_value ) {
 		if ( ! $this->CanLogMetaKey( $object_id, $meta_key ) || is_array( $meta_value ) ) {
@@ -222,7 +222,7 @@ class WSAL_Sensors_MetaData extends WSAL_AbstractSensor {
 	 * @param int    $meta_id - Meta ID.
 	 * @param int    $object_id - Object ID.
 	 * @param string $meta_key - Meta key.
-	 * @param mix    $meta_value - Meta value.
+	 * @param mixed  $meta_value - Meta value.
 	 */
 	public function EventPostMetaUpdated( $meta_id, $object_id, $meta_key, $meta_value ) {
 		if ( ! $this->CanLogMetaKey( $object_id, $meta_key ) || is_array( $meta_value ) ) {
@@ -339,7 +339,7 @@ class WSAL_Sensors_MetaData extends WSAL_AbstractSensor {
 	 * @param int    $meta_ids - Meta IDs.
 	 * @param int    $object_id - Object ID.
 	 * @param string $meta_key - Meta key.
-	 * @param mix    $meta_value - Meta value.
+	 * @param mixed  $meta_value - Meta value.
 	 */
 	public function EventPostMetaDeleted( $meta_ids, $object_id, $meta_key, $meta_value ) {
 		// If meta key starts with "_" then return.
@@ -439,7 +439,7 @@ class WSAL_Sensors_MetaData extends WSAL_AbstractSensor {
 	 *
 	 * @param int    $object_id - Object ID.
 	 * @param string $meta_key - Meta key.
-	 * @param mix    $meta_value - Meta value.
+	 * @param mixed  $meta_value - Meta value.
 	 */
 	public function event_user_meta_created( $object_id, $meta_key, $meta_value ) {
 		// Get user.
@@ -502,7 +502,7 @@ class WSAL_Sensors_MetaData extends WSAL_AbstractSensor {
 	 * @param int    $meta_id - Meta ID.
 	 * @param int    $object_id - Object ID.
 	 * @param string $meta_key - Meta key.
-	 * @param mix    $meta_value - Meta value.
+	 * @param mixed  $meta_value - Meta value.
 	 */
 	public function event_user_meta_updated( $meta_id, $object_id, $meta_key, $meta_value ) {
 		// Get user.

--- a/classes/Sensors/WooCommerce.php
+++ b/classes/Sensors/WooCommerce.php
@@ -1578,7 +1578,6 @@ class WSAL_Sensors_WooCommerce extends WSAL_AbstractSensor {
 			'LRD' => '&#36;',
 			'LSL' => 'L',
 			'LYD' => '&#x644;.&#x62f;',
-			'MAD' => '&#x62f;. &#x645;.',
 			'MAD' => '&#x62f;.&#x645;.',
 			'MDL' => 'L',
 			'MGA' => 'Ar',

--- a/classes/Sensors/YoastSEO.php
+++ b/classes/Sensors/YoastSEO.php
@@ -119,7 +119,7 @@ class WSAL_Sensors_YoastSEO extends WSAL_AbstractSensor {
 	 * Method: Get Post SEO Data.
 	 *
 	 * @param string $key – Meta Key.
-	 * @return mix
+	 * @return mixed
 	 */
 	protected function get_post_seo_data( $key = '' ) {
 		// If empty key then return false.
@@ -491,8 +491,8 @@ class WSAL_Sensors_YoastSEO extends WSAL_AbstractSensor {
 	 * Method: Yoast SEO options trigger.
 	 *
 	 * @param string $option – Option name.
-	 * @param mix    $old_value – Option old value.
-	 * @param mix    $new_value – Option new value.
+	 * @param mixed  $old_value – Option old value.
+	 * @param mixed  $new_value – Option new value.
 	 */
 	public function yoast_options_trigger( $option, $old_value, $new_value ) {
 		// Detect the SEO option.
@@ -687,7 +687,7 @@ class WSAL_Sensors_YoastSEO extends WSAL_AbstractSensor {
 	 * Method: Trigger Yoast Enable/Disable Setting Alerts.
 	 *
 	 * @param string $key – Setting index to alert.
-	 * @param mix    $new_value – Setting new value.
+	 * @param mixed  $new_value – Setting new value.
 	 */
 	private function yoast_setting_switch_alert( $key, $new_value ) {
 		// If key is empty, then return.

--- a/classes/Settings.php
+++ b/classes/Settings.php
@@ -1480,7 +1480,7 @@ class WSAL_Settings {
 	 * Method: Meta data formater.
 	 *
 	 * @param string  $name      - Name of the data.
-	 * @param mix     $value     - Value of the data.
+	 * @param mixed   $value     - Value of the data.
 	 * @param integer $occ_id    - Event occurrence ID.
 	 * @param mixed   $highlight - Highlight format.
 	 * @return string
@@ -1747,7 +1747,7 @@ class WSAL_Settings {
 	 * @since 3.3
 	 *
 	 * @param string  $name      - Name of the data.
-	 * @param mix     $value     - Value of the data.
+	 * @param mixed   $value     - Value of the data.
 	 * @param integer $occ_id    - Event occurrence ID.
 	 * @param mixed   $highlight - Highlight format.
 	 * @return string

--- a/wp-security-audit-log.php
+++ b/wp-security-audit-log.php
@@ -106,14 +106,14 @@ if ( ! function_exists( 'wsal_freemius' ) ) {
 		/**
 		 * Licenses manager.
 		 *
-		 * @var WSAL_LicenseManage
+		 * @var WSAL_LicenseManager
 		 */
 		public $licensing;
 
 		/**
 		 * Options.
 		 *
-		 * @var WSAL_DB_Option
+		 * @var WSAL_Models_Option
 		 */
 		public $options;
 
@@ -1480,7 +1480,7 @@ if ( ! function_exists( 'wsal_freemius' ) ) {
 		 * Update global option.
 		 *
 		 * @param string $option - Option name.
-		 * @param mix    $value - Option value.
+		 * @param mixed  $value - Option value.
 		 */
 		public function UpdateGlobalOption( $option, $value ) {
 			$this->options = new WSAL_Models_Option();

--- a/wp-security-audit-log.php
+++ b/wp-security-audit-log.php
@@ -1566,7 +1566,7 @@ if ( ! function_exists( 'wsal_freemius' ) ) {
 		 *
 		 * Logs given input into debug.log file in debug mode.
 		 *
-		 * @param mix $message - Error message.
+		 * @param mixed $message - Error message.
 		 */
 		public function wsal_log( $message ) {
 			if ( WP_DEBUG === true ) {


### PR DESCRIPTION
- fixed typehint (`mixed` instead of `mix`)
- replaced initialising abstract class (which causes an error) with a proper exception
- fixed old class names typehint (eg `WSAL_Meta` should be `WSAL_Models_Meta`)
- fixed typo in some variables names and comments
- use non-static method properly (`self::LoadMultiQuery` should be `$this->LoadMultiQuery`)
- removed duplicate key entry in WooCommerce sensor
- ensured array of tags is actually an array (by typecasting)
- avoid notices/warnings when a null is passed instead of a post object