### PR TITLE
Resolve warning from incorrect use of add_submenu_page

### DIFF
--- a/classes/ViewManager.php
+++ b/classes/ViewManager.php
@@ -245,8 +245,7 @@ class WSAL_ViewManager {
 						$view->GetName(),
 						'read', // No capability requirement.
 						$view->GetSafeViewName(),
-						array( $this, 'RenderViewBody' ),
-						$view->GetIcon()
+						array( $this, 'RenderViewBody' )
 					);
 				}
 			}


### PR DESCRIPTION
The `add_submenu_page` function [does not accept an `icon` as its final parameter](https://developer.wordpress.org/reference/functions/add_submenu_page/).

This is not normally a problem (the extra parameter is silently disregarded) however [WordPress 5.3 introduces a new parameter](https://github.com/WordPress/WordPress/blob/554b60da762c86b5eed577001432f1266f32a71c/wp-admin/includes/plugin.php#L1342), `$position`, which is expected to be an `int` or `null`. Passing the string now causes a PHP warning.

The warning was observed in WordPress 5.3 RC1 and WP Security Audit Log Premium.