### PR TITLE
It's not necessary to restrict dashboard widgets to the index.php page

### DIFF
--- a/classes/WidgetManager.php
+++ b/classes/WidgetManager.php
@@ -43,12 +43,9 @@ class WSAL_WidgetManager {
 	 * Method: Add widgets.
 	 */
 	public function add_widgets() {
-		global $pagenow;
-
 		if (
 			$this->_plugin->settings()->IsWidgetsEnabled() // If widget is enabled.
 			&& $this->_plugin->settings()->CurrentUserCan( 'view' ) // If user has permission to view.
-			&& 'index.php' === $pagenow // If the current page is dashboard.
 		) {
 			wp_add_dashboard_widget(
 				'wsal',


### PR DESCRIPTION
Hey there :)

Not further restricting wp_add_dashboard_widget() to the actual dashboard page would allow us to recognize the dashboard widget in our Ultimate Dashboard PRO plugin.

In general, it's not necessary to do that as thee wp_add_dashboard_widget won't register the widget anywhere else except the dashboard.

Thank you for considering the change!

Best,
David