### PR TITLE
EventLoginBlocked not defined

### DIFF
--- a/classes/Sensors/LogInOut.php
+++ b/classes/Sensors/LogInOut.php
@@ -326,15 +326,14 @@ class WSAL_Sensors_LogInOut extends WSAL_AbstractSensor {
 	}
 
 	/**
-   * Event Login blocked
-   *
-   * This is simply a stub to stop the add_filter which refers to this method
-   *  in the HookEvents method from generating an error
+	 * Event Login blocked
+	 *
+	 * This is simply a stub to stop the add_filter which refers to this method
+	 *  in the HookEvents method from generating an error
 	 *
 	 * @param string $username Username.
 	 */
-  public function EventLoginBlocked( $username ) {}
-
+	public function EventLoginBlocked( $username ) {}
 
 	/**
 	 * Event Login failure.

--- a/classes/Sensors/LogInOut.php
+++ b/classes/Sensors/LogInOut.php
@@ -326,6 +326,17 @@ class WSAL_Sensors_LogInOut extends WSAL_AbstractSensor {
 	}
 
 	/**
+   * Event Login blocked
+   *
+   * This is simply a stub to stop the add_filter which refers to this method
+   *  in the HookEvents method from generating an error
+	 *
+	 * @param string $username Username.
+	 */
+  public function EventLoginBlocked( $username ) {}
+
+
+	/**
 	 * Event Login failure.
 	 *
 	 * @param string $username Username.


### PR DESCRIPTION
The WSAL_Sensors_LogInOut class adds a filter that refers to an undefined EventLoginBlocked method 

This pull request adds a stub method to stop this generating an error message.