### PR TITLE
Multisite: switch_to_blog expects a blog_id

### DIFF
--- a/classes/Helpers/Options.php
+++ b/classes/Helpers/Options.php
@@ -112,7 +112,7 @@ class Options {
 	public function delete_option( $option_name = '' ) {
 
 		if ( is_multisite() ) {
-			switch_to_blog( get_main_network_id() );
+			switch_to_blog( get_main_site_id() );
 		}
 
 		$actual_option_name = $option_name;
@@ -167,7 +167,7 @@ class Options {
 		}
 
 		if ( is_multisite() ) {
-			switch_to_blog( get_main_network_id() );
+			switch_to_blog( get_main_site_id() );
 		}
 
 		$result = \get_option( $option_name, $default );
@@ -219,7 +219,7 @@ class Options {
 		}
 
 		if ( is_multisite() ) {
-			switch_to_blog( get_main_network_id() );
+			switch_to_blog( get_main_site_id() );
 		}
 
 		/**

--- a/classes/Helpers/class-wp-helper.php
+++ b/classes/Helpers/class-wp-helper.php
@@ -197,7 +197,7 @@ if ( ! class_exists( '\WSAL\Helpers\WP_Helper' ) ) {
 			$prefixed_name = self::prefix_name( $option_name );
 
 			if ( self::is_multisite() ) {
-				\switch_to_blog( \get_main_network_id() );
+				\switch_to_blog( \get_main_site_id() );
 			}
 
 			$result = \delete_option( $prefixed_name );
@@ -244,7 +244,7 @@ if ( ! class_exists( '\WSAL\Helpers\WP_Helper' ) ) {
 			$prefixed_name = self::prefix_name( $option_name );
 
 			if ( is_multisite() ) {
-				\switch_to_blog( \get_main_network_id() );
+				\switch_to_blog( \get_main_site_id() );
 			}
 
 			$result = \update_option( $prefixed_name, $value, $autoload );
@@ -273,7 +273,7 @@ if ( ! class_exists( '\WSAL\Helpers\WP_Helper' ) ) {
 			}
 
 			if ( is_multisite() ) {
-				switch_to_blog( get_main_network_id() );
+				switch_to_blog( get_main_site_id() );
 			}
 
 			$prefixed_name = self::prefix_name( $option_name );


### PR DESCRIPTION
Hello,

`switch_to_blog(get_main_network_id());` shouldn’t be used.
Instead the code should be: `switch_to_blog(get_main_site_id());`
`switch_to_blog()` expects a blog ID, not a network ID.

Thanks