### PR TITLE
Fixes TypeError for post revisions link for PHP 8.1

### DIFF
--- a/classes/Sensors/Content.php
+++ b/classes/Sensors/Content.php
@@ -1599,16 +1599,17 @@ class WSAL_Sensors_Content { //extends WSAL_AbstractSensor {
 			$revision = array_shift( $revisions );
 			return $this->get_revision_link( $revision->ID );
 		}
+		return '';
 	}
 
 	/**
 	 * Builds revision link.
 	 *
 	 * @param integer $revision_id - Revision ID.
-	 * @return string|null - Link.
+	 * @return string - Link.
 	 */
 	private function get_revision_link( $revision_id ) {
-		return ! empty( $revision_id ) ? add_query_arg( 'revision', $revision_id, admin_url( 'revision.php' ) ) : null;
+		return ! empty( $revision_id ) ? add_query_arg( 'revision', $revision_id, admin_url( 'revision.php' ) ) : '';
 	}
 
 	/**

--- a/classes/WPSensors/class-wp-content-sensor.php
+++ b/classes/WPSensors/class-wp-content-sensor.php
@@ -1688,6 +1688,7 @@ if ( ! class_exists( '\WSAL\WP_Sensors\WP_Content_Sensor' ) ) {
 				$revision = array_shift( $revisions );
 				return self::get_revision_link( $revision->ID );
 			}
+			return '';
 		}
 
 		/**
@@ -1695,12 +1696,12 @@ if ( ! class_exists( '\WSAL\WP_Sensors\WP_Content_Sensor' ) ) {
 		 *
 		 * @param integer $revision_id - Revision ID.
 		 *
-		 * @return string|null - Link.
+		 * @return string - Link.
 		 *
 		 * @since 4.5.0
 		 */
 		private static function get_revision_link( $revision_id ) {
-			return ! empty( $revision_id ) ? add_query_arg( 'revision', $revision_id, admin_url( 'revision.php' ) ) : null;
+			return ! empty( $revision_id ) ? add_query_arg( 'revision', $revision_id, admin_url( 'revision.php' ) ) : '';
 		}
 
 		/**


### PR DESCRIPTION
Fixes get_post_revision and get_revision_link return data and sets empty string rather than null to avoid TypeError when logging post update event for post types that does not support Revisions. 

The function get_post_revision was not explicitly returning empty string when there was empty data for wp_get_post_revisions, causing null to be return, while the return type for the function is STRING.

Similarly,  get_revision_link was returning null instead of empty string and updated it as this data is being used in get_post_revision function.

On sites running PHP8.1 with Strict Type enabled, when a Post of Post Type that does not support Post Revision is updated, a TypeError is encountered when logging the update event. 
Here, the data for the RevisionLink was coming as null instead of empty string, causing the addslashes() functions to fail as it expects STRING data.

Stack trace for the encountered issue : 

NOTICE: PHP message: Whoops\Exception\ErrorException: addslashes(): Passing null to parameter #1 ($string) of type string is deprecated in /wp/wp-content/mu-plugins/drop-ins/hyperdb/db.php:844

Stack trace:

#0 [internal function]: Whoops\Run->handleError(8192, 'addslashes(): P...', '/wp/wp-content/...', 844)
#1 /wp/wp-content/mu-plugins/drop-ins/hyperdb/db.php(844): addslashes(NULL)
#2 /wp/wp-includes/class-wpdb.php(1789): hyperdb->_real_escape(NULL)
#3 /wp/wp-content/plugins/wp-security-audit-log/classes/Entities/class-occurrences-entity.php(221): wpdb->prepare('(%d, '%s', '%s'...', Array)
#4 /wp/wp-content/plugins/wp-security-audit-log/classes/Loggers/Database.php(98): WSAL\Entities\Occurrences_Entity::store_record(Array, 2065, '1694787603.8227...', 1)
#5 /wp/wp-content/plugins/wp-security-audit-log/classes/Controllers/class-alert-manager.php(782): WSAL\Loggers\WSAL_Loggers_Database->log(2065, Array)
#6 /wp/wp-content/plugins/wp-security-audit-log/classes/Controllers/class-alert-manager.php(540): WSAL\Controllers\Alert_Manager::log(2065, Array)
#7 /wp/wp-content/plugins/wp-security-audit-log/classes/Controllers/class-alert-manager.php(253): WSAL\Controllers\Alert_Manager::commit_item(2065, Array, NULL)
#8 /wp/wp-content/plugins/wp-security-audit-log/classes/WPSensors/class-wp-content-sensor.php(1607): WSAL\Controllers\Alert_Manager::trigger_event(2065, Array)
#9 /wp/wp-content/plugins/wp-security-audit-log/classes/WPSensors/class-wp-content-sensor.php(250): WSAL\WP_Sensors\WP_Content_Sensor::check_modification_change(7, Object(WP_Post), Object(WP_Post), 0)
#10 /wp/wp-includes/class-wp-hook.php(310): WSAL\WP_Sensors\WP_Content_Sensor::post_changed(7, Object(WP_Post), true)