### PR TITLE
Fix foreach php error in Alert_Manager

### DIFF
--- a/classes/Controllers/class-alert-manager.php
+++ b/classes/Controllers/class-alert-manager.php
@@ -983,6 +983,9 @@ if ( ! class_exists( '\WSAL\Controllers\Alert_Manager' ) ) {
 			}
 
 			$last_occurrences = self::get_latest_events( 5 );
+			if ( ! is_array( $last_occurrences ) ) {
+				return false;
+			}
 
 			$known_to_trigger = false;
 			foreach ( $last_occurrences as $last_occurrence ) {


### PR DESCRIPTION
The `Alert_Manager::get_latest_events` method returns either a bool or an array. 

Instead of assuming the result is an array we type check it before using to prevent PHP errors

```
PHP message: PHP Warning:  foreach() argument must be of type array|object, bool given in /var/www/wp-content/plugins/wp-security-audit-log/classes/Controllers/class-alert-manager.php on line 988
```

